### PR TITLE
fix:isHtlc to verify variable wait time encoding

### DIFF
--- a/btc/scripts.go
+++ b/btc/scripts.go
@@ -47,7 +47,7 @@ func HtlcScript(ownerPub, revokerPub, refundSecretHash []byte, waitTime int64) (
 }
 
 func isNumOpCode(opcode byte) bool {
-	return opcode >= 0x52 && opcode <= 0x60
+	return opcode >= 0x51 && opcode <= 0x60
 }
 
 func isPushDataOpCode(opcode byte) bool {

--- a/btc/scripts_test.go
+++ b/btc/scripts_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Bitcoin scripts", func() {
 			By("Construct a tx which transferring funds from multisig to the HTLC")
 			secret := testutil.RandomSecret()
 			secretHash := sha256.Sum256(secret)
-			waitTime := int64(6)
+			waitTime := int64(20)
 			// pk1 can redeem the funds after expiry
 			// pk2 can redeem the funds if knowing the secret
 			htlcScript, err := btc.HtlcScript(btcutil.Hash160(pubKey1.SerializeCompressed()), btcutil.Hash160(pubKey2.SerializeCompressed()), secretHash[:], waitTime)


### PR DESCRIPTION
- wait time is number which can represented by opcodes 0x51-0x60 (1 - 16) or as data with pushdata opcode
- added 0xff to represent variable length data for verification