### PR TITLE
Fix blockstream api fee tests

### DIFF
--- a/btc/fee_test.go
+++ b/btc/fee_test.go
@@ -92,9 +92,9 @@ var _ = Describe("bitcoin fees", func() {
 				fees, err := estimator.FeeSuggestion()
 				Expect(err).Should(BeNil())
 
-				Expect(fees.Minimum).Should(BeNumerically(">", 1))
+				Expect(fees.Minimum).Should(BeNumerically(">=", 1))
 
-				Expect(fees.Economy).Should(BeNumerically(">", 1))
+				Expect(fees.Economy).Should(BeNumerically(">=", 1))
 				Expect(fees.Economy).Should(BeNumerically(">=", fees.Minimum))
 
 				Expect(fees.Low).Should(BeNumerically(">", 1))


### PR DESCRIPTION
Sometimes the fee data returned by [blockstream](https://blockstream.info/testnet/api/fee-estimates) does not meet our testcases. Just added necessary conditions to match it properly.