### PR TITLE
chore: refactored batch struct to save vouts,mergeTxFee; added function to handle data post submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Example:
 
 ### Fee estimator
 
-The fee estimator estimates network fees using various APIs.
+The fee estimator gs network fees using various APIs.
 > The result is in `sats/vB`
 
 Example:

--- a/btc/client.go
+++ b/btc/client.go
@@ -1,9 +1,15 @@
 package btc
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
 	"strings"
 
 	"github.com/btcsuite/btcd/btcjson"
@@ -338,4 +344,107 @@ func (client *client) GetNetworkInfo(ctx context.Context) (*btcjson.GetNetworkIn
 	case result := <-results:
 		return result, nil
 	}
+}
+
+type RPCRequest struct {
+	Jsonrpc string        `json:"jsonrpc"`
+	ID      string        `json:"id"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+}
+
+type Fees struct {
+	Base       float64 `json:"base"`
+	Modified   float64 `json:"modified"`
+	Ancestor   float64 `json:"ancestor"`
+	Descendant float64 `json:"descendant"`
+}
+
+// Transaction represents a single transaction entry
+type DescendantTransaction struct {
+	Vsize             int      `json:"vsize"`
+	Weight            int      `json:"weight"`
+	Time              int64    `json:"time"`
+	Height            int      `json:"height"`
+	DescendantCount   int      `json:"descendantcount"`
+	DescendantSize    int      `json:"descendantsize"`
+	AncestorCount     int      `json:"ancestorcount"`
+	AncestorSize      int      `json:"ancestorsize"`
+	WtxID             string   `json:"wtxid"`
+	Fees              Fees     `json:"fees"`
+	Depends           []string `json:"depends"`
+	SpentBy           []string `json:"spentby"`
+	BIP125Replaceable bool     `json:"bip125-replaceable"`
+	Unbroadcast       bool     `json:"unbroadcast"`
+}
+
+type BitcoinRPCClient struct {
+	RpcUser string
+	RpcPass string
+	RpcURL  string
+}
+
+func (b *BitcoinRPCClient) GetDescendants(ctx context.Context, txId string) int64 {
+	verbose := true
+	// Create the JSON-RPC request
+	requestBody := RPCRequest{
+		Jsonrpc: "1.0",
+		ID:      "curltext",
+		Method:  "getmempooldescendants",
+		Params:  []interface{}{txId, verbose},
+	}
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		log.Fatalf("Error marshalling JSON: %v", err)
+	}
+
+	// Create a new HTTP request
+	req, err := http.NewRequestWithContext(ctx, "POST", b.RpcURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Fatalf("Error creating request: %v", err)
+	}
+
+	// Add headers
+	req.Header.Set("Content-Type", "text/plain")
+	req.SetBasicAuth(b.RpcUser, b.RpcPass)
+
+	// Send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Error reading response: %v", err)
+	}
+
+	var apiResponse struct {
+		Result map[string]DescendantTransaction `json:"result"`
+		Error  interface{}                      `json:"error"`
+		ID     string                           `json:"id"`
+	}
+
+	if err := json.Unmarshal(body, &apiResponse); err != nil {
+		log.Fatalf("Error unmarshalling JSON: %v", err)
+	}
+
+	if len(apiResponse.Result) == 0 {
+		return 0
+	}
+
+	transactions := make([]DescendantTransaction, 0, len(apiResponse.Result))
+	for _, tx := range apiResponse.Result {
+		transactions = append(transactions, tx)
+	}
+
+	var sum float64
+	for _, tx := range transactions {
+		sum += tx.Fees.Base
+	}
+
+	return int64(math.Round(sum * 100000000))
 }

--- a/btc/guardian/batch.go
+++ b/btc/guardian/batch.go
@@ -8,6 +8,7 @@ import (
 
 type Batch struct {
 	Tx              btc.Transaction
+	// maps RequestId to Vouts in Tx
 	RequestIds      map[string]int
 	PreviousBatchID string
 	MergeTxFee      int64

--- a/btc/guardian/batch.go
+++ b/btc/guardian/batch.go
@@ -8,15 +8,19 @@ import (
 
 type Batch struct {
 	Tx              btc.Transaction
-	RequestIds      []string
+	RequestIds      map[string]int
 	PreviousBatchID string
+	MergeTxFee      int64
 }
 
-func NewBatch(tx btc.Transaction, requestIds []string, previousBatchID string) *Batch {
+const CoinbaseBatchID = "coinbase"
+
+func NewBatch(tx btc.Transaction, requestIds map[string]int, previousBatchID string, mergeTxFee int64) *Batch {
 	return &Batch{
 		Tx:              tx,
 		RequestIds:      requestIds,
 		PreviousBatchID: previousBatchID,
+		MergeTxFee:      mergeTxFee,
 	}
 }
 

--- a/btc/guardian/batch.go
+++ b/btc/guardian/batch.go
@@ -15,6 +15,8 @@ type Batch struct {
 }
 
 const CoinbaseBatchID = "coinbase"
+const GuardianChangeSize = 267
+const GuardianWitnessSize = 43
 
 func NewBatch(tx btc.Transaction, requestIds map[string]int, previousBatchID string, mergeTxFee int64) *Batch {
 	return &Batch{

--- a/btc/guardian/batch.go
+++ b/btc/guardian/batch.go
@@ -15,8 +15,8 @@ type Batch struct {
 }
 
 const CoinbaseBatchID = "coinbase"
-const GuardianChangeSize = 267
-const GuardianWitnessSize = 43
+const GuardianWitnessSize = 267
+const GuardianChangeSize = 43
 
 func NewBatch(tx btc.Transaction, requestIds map[string]int, previousBatchID string, mergeTxFee int64) *Batch {
 	return &Batch{

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -716,7 +716,7 @@ func (w *Wallet) adjustFee(ctx context.Context, tx *wire.MsgTx, totalInAmount in
 		extraBaseSize = 43
 	}
 
-	feeToBePaid, err := btc.EstimateGuardianFee(tx, w.feeEstimator, w.feeLevel, int(previousFeeRate), GuardianChangeSize, extraBaseSize)
+	feeToBePaid, err := btc.EstimateGuardianFee(tx, w.feeEstimator, w.feeLevel, int(previousFeeRate), GuardianWitnessSize, extraBaseSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to estimate fee: %w", err)
 	}
@@ -768,7 +768,7 @@ func (w *Wallet) adjustFee(ctx context.Context, tx *wire.MsgTx, totalInAmount in
 					tx.AddTxIn(txIn)
 				}
 			}
-			newFee, err := btc.EstimateGuardianFee(tx, w.feeEstimator, w.feeLevel, int(previousFeeRate), GuardianChangeSize, GuardianWitnessSize)
+			newFee, err := btc.EstimateGuardianFee(tx, w.feeEstimator, w.feeLevel, int(previousFeeRate), GuardianWitnessSize, GuardianChangeSize)
 			if err != nil {
 				return nil, fmt.Errorf("failed to estimate fee: %w", err)
 			}

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -151,19 +151,19 @@ func (w *Wallet) shouldCreateNewBatch(ctx context.Context) (*Batch, bool, error)
 	return batch, confirmed, nil
 }
 
-func (w *Wallet) getVoutIndicesForMergeRequests(ctx context.Context, mergeRequestIDs []string) ([]int, error) {
+func (w *Wallet) getVoutIndicesForMergeRequests(mergeRequestIDs []string, onGoingBatch *Batch) ([]int, error) {
 	indices := []int{}
 	for _, id := range mergeRequestIDs {
-		vout, err := w.cache.ReadRequestVOUT(ctx, id)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read request vout: %w", err)
+		vout, ok := onGoingBatch.RequestIds[id]
+		if ok == false {
+			return nil, fmt.Errorf("failed to read request vout from batch")
 		}
 		indices = append(indices, vout)
 	}
 	return indices, nil
 }
 
-func (w *Wallet) handleMergeRequests(ctx context.Context, tx *wire.MsgTx, req []btc.SendRequest, onGoingBatch *Batch) (*wire.MsgTx, []*TxOutput, []string, error) {
+func (w *Wallet) handleMergeRequests(tx *wire.MsgTx, req []btc.SendRequest, onGoingBatch *Batch) (*wire.MsgTx, []*TxOutput, []string, error) {
 	// check for merges, and if there are there, we need to remove them from the tx
 
 	remainingRequests, mergeIDs, mergeTxHexes, err := extractMergeIDs(req, onGoingBatch)
@@ -174,7 +174,7 @@ func (w *Wallet) handleMergeRequests(ctx context.Context, tx *wire.MsgTx, req []
 
 	prettyPrint(mergeIDs)
 
-	indices, err := w.getVoutIndicesForMergeRequests(ctx, mergeIDs)
+	indices, err := w.getVoutIndicesForMergeRequests(mergeIDs, onGoingBatch)
 	if err != nil {
 		w.logger.Error("Failed to get vout indices for merge requests", zap.Error(err))
 		return nil, nil, nil, fmt.Errorf("failed to get vout indices for merge requests: %w", err)
@@ -213,7 +213,7 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 		return chainhash.Hash{}, fmt.Errorf("failed to get raw tx from batch: %w", err)
 	}
 
-	tx, newTxOuts, mergeTxHexes, err := w.handleMergeRequests(ctx, tx, req, onGoingBatch)
+	tx, newTxOuts, mergeTxHexes, err := w.handleMergeRequests(tx, req, onGoingBatch)
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to handle merge requests: %w", err)
 	}
@@ -233,7 +233,7 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to adjust fee: %w", err)
 	}
-	tx, mergeTxFee, err := w.includeMergeTxFee(ctx, tx, mergeTxHexes)
+	tx, mergeTxFee, err := w.includeMergeTxFee(ctx, tx, mergeTxHexes, onGoingBatch.MergeTxFee)
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to include merge tx fee: %w", err)
 	}
@@ -285,7 +285,7 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 	for reqID, vout := range reqIDs {
 		onGoingBatch.RequestIds[reqID] = vout
 	}
-	
+
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
 	}
@@ -698,12 +698,8 @@ func (w *Wallet) getChangeAmount(tx *wire.MsgTx) int64 {
 	return 0
 }
 
-func (w *Wallet) includeMergeTxFee(ctx context.Context, tx *wire.MsgTx, mergeTxHexes []string) (*wire.MsgTx, int64, error) {
-	mergeTxFee, err := w.cache.ReadMergeTxFee(ctx)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to read merge tx fee: %w", err)
-	}
-
+func (w *Wallet) includeMergeTxFee(ctx context.Context, tx *wire.MsgTx, mergeTxHexes []string, mergeTxFee int64) (*wire.MsgTx, int64, error) {
+	var err error
 	if len(mergeTxHexes) > 0 {
 		if mergeTxFee > 0 {
 			tx, err = w.decreaseChangeAmount(tx, mergeTxFee+1)

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -6,10 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
-	"log"
-	"math"
-	"net/http"
 	"strings"
 	"time"
 
@@ -36,9 +32,10 @@ type Wallet struct {
 	logger         *zap.Logger
 	addr           btcutil.Address
 	pkScript       []byte
+	rpc            btc.BitcoinRPCClient
 }
 
-func NewWallet(client *GuardianClient, privKey *btcec.PrivateKey, cache Cache, indexer btc.IndexerClient, chainParams *chaincfg.Params, feeEstimator btc.FeeEstimator, logger *zap.Logger, feeLevel ...btc.FeeLevel) (*Wallet, error) {
+func NewWallet(client *GuardianClient, privKey *btcec.PrivateKey, cache Cache, indexer btc.IndexerClient, chainParams *chaincfg.Params, feeEstimator btc.FeeEstimator, logger *zap.Logger, rpcconfig btc.BitcoinRPCClient, feeLevel ...btc.FeeLevel) (*Wallet, error) {
 	defaultFeeLevel := btc.MediumFee
 	if len(feeLevel) > 0 {
 		defaultFeeLevel = feeLevel[0]
@@ -80,6 +77,7 @@ func NewWallet(client *GuardianClient, privKey *btcec.PrivateKey, cache Cache, i
 		logger:         logger,
 		addr:           addr,
 		pkScript:       pkScript,
+		rpc:            rpcconfig,
 	}, nil
 }
 
@@ -244,7 +242,7 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 		return chainhash.Hash{}, fmt.Errorf("failed to get in amounts: %w", err)
 	}
 
-	fee := getDescendantsFee(onGoingBatch.Tx.TxID)
+	fee := w.rpc.GetDescendants(ctx, onGoingBatch.Tx.TxID)
 
 	onGoingBatch.MergeTxFee += fee
 
@@ -1065,121 +1063,4 @@ func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx 
 	}
 
 	return nil
-}
-
-// func getDescendants (txId string) {
-// 	connCfg := &rpcclient.ConnConfig{
-// 		Host:         "localhost:18443",
-// 		User:         "admin1",
-// 		Pass:         "123",
-// 		HTTPPostMode: true, // Namecoin core only supports HTTP POST mode
-// 		DisableTLS:   true, // Namecoin core does not provide TLS by default
-// 	}
-// 	client, err := rpcclient.New(connCfg, nil)
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	defer client.Shutdown()
-// 	result := client.SendCmd("getdescendants")
-// 	fmt.Println(result)
-// }
-
-type RPCRequest struct {
-	Jsonrpc string        `json:"jsonrpc"`
-	ID      string        `json:"id"`
-	Method  string        `json:"method"`
-	Params  []interface{} `json:"params"`
-}
-
-type Fees struct {
-	Base       float64 `json:"base"`
-	Modified   float64 `json:"modified"`
-	Ancestor   float64 `json:"ancestor"`
-	Descendant float64 `json:"descendant"`
-}
-
-// Transaction represents a single transaction entry
-type Transaction struct {
-	Vsize             int      `json:"vsize"`
-	Weight            int      `json:"weight"`
-	Time              int64    `json:"time"`
-	Height            int      `json:"height"`
-	DescendantCount   int      `json:"descendantcount"`
-	DescendantSize    int      `json:"descendantsize"`
-	AncestorCount     int      `json:"ancestorcount"`
-	AncestorSize      int      `json:"ancestorsize"`
-	WtxID             string   `json:"wtxid"`
-	Fees              Fees     `json:"fees"`
-	Depends           []string `json:"depends"`
-	SpentBy           []string `json:"spentby"`
-	BIP125Replaceable bool     `json:"bip125-replaceable"`
-	Unbroadcast       bool     `json:"unbroadcast"`
-}
-
-func getDescendantsFee(txId string) int64 {
-	rpcUser := "admin1"
-	rpcPass := "123"
-	rpcURL := "http://0.0.0.0:18443/"
-	verbose := true
-	// Create the JSON-RPC request
-	requestBody := RPCRequest{
-		Jsonrpc: "1.0",
-		ID:      "curltext",
-		Method:  "getmempooldescendants",
-		Params:  []interface{}{txId, verbose}, // Empty params
-	}
-	jsonData, err := json.Marshal(requestBody)
-	if err != nil {
-		log.Fatalf("Error marshalling JSON: %v", err)
-	}
-
-	// Create a new HTTP request
-	req, err := http.NewRequest("POST", rpcURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		log.Fatalf("Error creating request: %v", err)
-	}
-
-	// Add headers
-	req.Header.Set("Content-Type", "text/plain")
-	req.SetBasicAuth(rpcUser, rpcPass)
-
-	// Send the request
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Fatalf("Error sending request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	// Read response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Fatalf("Error reading response: %v", err)
-	}
-
-	var apiResponse struct {
-		Result map[string]Transaction `json:"result"`
-		Error  interface{}            `json:"error"`
-		ID     string                 `json:"id"`
-	}
-
-	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		log.Fatalf("Error unmarshalling JSON: %v", err)
-	}
-
-	if len(apiResponse.Result) == 0 {
-		return 0
-	}
-
-	transactions := make([]Transaction, 0, len(apiResponse.Result))
-	for _, tx := range apiResponse.Result {
-		transactions = append(transactions, tx)
-	}
-
-	var sum float64
-	for _, tx := range transactions {
-		sum += tx.Fees.Base
-	}
-
-	return int64(math.Round(sum * 100000000))
 }

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -35,7 +35,9 @@ type Wallet struct {
 	rpc            btc.BitcoinRPCClient
 }
 
-func NewWallet(client *GuardianClient, privKey *btcec.PrivateKey, cache Cache, indexer btc.IndexerClient, chainParams *chaincfg.Params, feeEstimator btc.FeeEstimator, logger *zap.Logger, rpcconfig btc.BitcoinRPCClient, feeLevel ...btc.FeeLevel) (*Wallet, error) {
+const indexerTimeout = 3 * time.Second
+
+func NewWallet(client *GuardianClient, privKey *btcec.PrivateKey, cache Cache, indexer btc.IndexerClient, chainParams *chaincfg.Params, feeEstimator btc.FeeEstimator, logger *zap.Logger, bitcoinRPC btc.BitcoinRPCClient, feeLevel ...btc.FeeLevel) (*Wallet, error) {
 	defaultFeeLevel := btc.MediumFee
 	if len(feeLevel) > 0 {
 		defaultFeeLevel = feeLevel[0]
@@ -77,7 +79,7 @@ func NewWallet(client *GuardianClient, privKey *btcec.PrivateKey, cache Cache, i
 		logger:         logger,
 		addr:           addr,
 		pkScript:       pkScript,
-		rpc:            rpcconfig,
+		rpc:            bitcoinRPC,
 	}, nil
 }
 
@@ -883,9 +885,9 @@ func prettyPrint(anything interface{}) {
 func (w *Wallet) getInAmounts(ctx context.Context, tx *wire.MsgTx) ([]int64, int64, error) {
 	amounts := []int64{}
 	for _, in := range tx.TxIn {
-		childCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-		defer cancel()
-		prevTx, err := w.indexer.GetTx(childCtx, in.PreviousOutPoint.Hash.String())
+		ctx, cancel := context.WithTimeout(ctx, indexerTimeout)
+		prevTx, err := w.indexer.GetTx(ctx, in.PreviousOutPoint.Hash.String())
+		cancel()
 		if err != nil {
 			return nil, 0, err
 		}
@@ -907,7 +909,7 @@ func (w *Wallet) getTotalOutAmount(tx *wire.MsgTx) int64 {
 }
 
 func (w *Wallet) batchStatus(ctx context.Context, batch *Batch) (bool, bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, indexerTimeout)
 	defer cancel()
 	tx, err := w.indexer.GetTx(ctx, batch.Tx.TxID)
 	if err != nil {
@@ -923,7 +925,7 @@ func (w *Wallet) batchStatus(ctx context.Context, batch *Batch) (bool, bool, err
 
 func (w *Wallet) txFromBatch(ctx context.Context, batch *Batch) (*wire.MsgTx, error) {
 	// get the txHex from indexer
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, indexerTimeout)
 	defer cancel()
 	txHex, err := w.indexer.GetTxHex(ctx, batch.Tx.TxID)
 	if err != nil {
@@ -1028,7 +1030,7 @@ func (w *Wallet) selectAndAddUTXOsForNewOuts(ctx context.Context, tx *wire.MsgTx
 
 func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx *wire.MsgTx, workingBatch *Batch) error {
 
-	txCtx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+	txCtx, cancel := context.WithTimeout(ctx, indexerTimeout)
 	defer cancel()
 	batchTx, err := w.indexer.GetTx(txCtx, tx.TxHash().String())
 	if err != nil {

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -270,7 +270,7 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
-	err = w.saveLatestBatch(ctx, req, tx, onGoingBatch, "")
+	err = w.saveLatestBatch(ctx, req, tx, onGoingBatch)
 	return tx.TxHash(), err
 
 }
@@ -317,8 +317,6 @@ func extractMergeIDs(req []btc.SendRequest, batch *Batch) ([]btc.SendRequest, []
 			remainingRequests = append(remainingRequests, r)
 			continue
 		}
-
-		fmt.Println("id to merge", id)
 
 		for rID := range batch.RequestIds {
 			if rID == id {
@@ -551,7 +549,7 @@ func (w *Wallet) batchAndBroadcast(ctx context.Context, req []btc.SendRequest, p
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
-	err = w.saveLatestBatch(ctx, req, tx, previousBatch, CoinbaseBatchID)
+	err = w.saveLatestBatch(ctx, req, tx, previousBatch)
 	return tx.TxHash(), err
 }
 
@@ -1000,12 +998,12 @@ func (w *Wallet) selectAndAddUTXOsForNewOuts(ctx context.Context, tx *wire.MsgTx
 	return tx, nil
 }
 
-func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx *wire.MsgTx, workingBatch *Batch, previousID string) error {
+func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx *wire.MsgTx, workingBatch *Batch) error {
 
-	childCtx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+	txCtx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
 	defer cancel()
 
-	batchTx, err := w.indexer.GetTx(childCtx, tx.TxHash().String())
+	batchTx, err := w.indexer.GetTx(txCtx, tx.TxHash().String())
 	if err != nil {
 		return fmt.Errorf("failed to get tx: %w", err)
 	}
@@ -1016,29 +1014,19 @@ func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx 
 
 	var finalBatch *Batch
 	// Creating A New Batch
-	if previousID == CoinbaseBatchID {
-		if workingBatch != nil {
-			previousID = workingBatch.Tx.TxID
-			for req, vout := range workingBatch.RequestIds {
-				reqIDs[req] = vout
-			}
-		}
 
-		finalBatch = NewBatch(batchTx, reqIDs, previousID, 0)
-
+	if workingBatch == nil {
+		finalBatch = NewBatch(batchTx, reqIDs, CoinbaseBatchID, 0)
 	} else {
+		workingBatch.PreviousBatchID = workingBatch.Tx.TxID
 		workingBatch.Tx = batchTx
-		workingBatch.PreviousBatchID = batchTx.TxID
-
-		// vouts are necessary for merge requests
 		for reqID, vout := range reqIDs {
 			workingBatch.RequestIds[reqID] = vout
 		}
-
 		finalBatch = workingBatch
 	}
 
-	err = w.cache.SaveLatestBatch(childCtx, finalBatch)
+	err = w.cache.SaveLatestBatch(txCtx, finalBatch)
 	if err != nil {
 		return fmt.Errorf("failed to save batch: %w", err)
 	}

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -220,11 +220,17 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 
 	tx, err = w.tryAdjustingAmountsForNewOuts(ctx, tx, newTxOuts)
 	if err != nil {
+		if strings.Contains(err.Error(), "Transaction not found") {
+			return w.batchAndBroadcast(ctx, req, onGoingBatch)
+		}
 		return chainhash.Hash{}, fmt.Errorf("failed to adjust amounts for new outs: %w", err)
 	}
 
 	values, totalInAmount, err := w.getInAmounts(ctx, tx)
 	if err != nil {
+		if strings.Contains(err.Error(), "Transaction not found") {
+			return w.batchAndBroadcast(ctx, req, onGoingBatch)
+		}
 		return chainhash.Hash{}, fmt.Errorf("failed to get in amounts: %w", err)
 	}
 
@@ -236,6 +242,9 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 
 	tx, onGoingBatch.MergeTxFee, err = w.includeMergeTxFee(ctx, tx, mergeTxHexes, onGoingBatch.MergeTxFee)
 	if err != nil {
+		if strings.Contains(err.Error(), "Transaction not found") {
+			return w.batchAndBroadcast(ctx, req, onGoingBatch)
+		}
 		return chainhash.Hash{}, fmt.Errorf("failed to include merge tx fee: %w", err)
 	}
 
@@ -264,7 +273,7 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 			return chainhash.Hash{}, fmt.Errorf("failed to get batch status: %w", statusErr)
 		}
 		w.logger.Info("Batch status", zap.Bool("confirmed", confirmed), zap.Bool("notFound", notFound))
-		if confirmed || notFound || strings.Contains(err.Error(), "bad-txns-inputs-missingorspent") {
+		if strings.Contains(err.Error(), "bad-txns-inputs-missingorspent") || notFound || confirmed {
 			return w.batchAndBroadcast(ctx, req, onGoingBatch)
 		}
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
@@ -396,6 +405,9 @@ func (w *Wallet) mergeTxFee(ctx context.Context, txHex string) (int, error) {
 
 	_, totalInAmount, err := w.getInAmounts(ctx, msgTx)
 	if err != nil {
+		if strings.Contains(err.Error(), "Transaction not found") {
+			return 0, err
+		}
 		return 0, fmt.Errorf("failed to get in amounts: %w", err)
 	}
 
@@ -520,6 +532,9 @@ func (w *Wallet) batchAndBroadcast(ctx context.Context, req []btc.SendRequest, p
 
 	inValues, totalInAmount, err := w.getInAmounts(ctx, tx)
 	if err != nil {
+		if strings.Contains(err.Error(), "Transaction not found") {
+			return w.batchAndBroadcast(ctx, req, previousBatch)
+		}
 		return chainhash.Hash{}, fmt.Errorf("failed to get in amounts: %w", err)
 	}
 
@@ -664,6 +679,9 @@ func (w *Wallet) includeMergeTxFee(ctx context.Context, tx *wire.MsgTx, mergeTxH
 		for _, mergeTxHex := range mergeTxHexes {
 			fee, err := w.mergeTxFee(ctx, mergeTxHex)
 			if err != nil {
+				if strings.Contains(err.Error(), "Transaction not found") {
+					return nil, 0, nil
+				}
 				return nil, 0, fmt.Errorf("failed to get merge tx fee: %w", err)
 			}
 			tx, err = w.decreaseChangeAmount(tx, int64(fee))
@@ -796,6 +814,9 @@ func (w *Wallet) tryAdjustingAmountsForNewOuts(ctx context.Context, tx *wire.Msg
 
 	_, totalInAmount, err := w.getInAmounts(ctx, tx)
 	if err != nil {
+		if strings.Contains(err.Error(), "Transaction not found") {
+			return nil, err
+		}
 		return nil, fmt.Errorf("failed to get in amounts: %w", err)
 	}
 
@@ -1005,6 +1026,10 @@ func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx 
 
 	batchTx, err := w.indexer.GetTx(txCtx, tx.TxHash().String())
 	if err != nil {
+		if strings.Contains(err.Error(), "Transaction not found") {
+			_, err = w.batchAndBroadcast(ctx, req, workingBatch)
+			return err
+		}
 		return fmt.Errorf("failed to get tx: %w", err)
 	}
 	reqIDs, err := w.getVoutsFromTx(tx, req)

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -155,7 +155,7 @@ func (w *Wallet) getVoutIndicesForMergeRequests(mergeRequestIDs []string, onGoin
 	indices := []int{}
 	for _, id := range mergeRequestIDs {
 		vout, ok := onGoingBatch.RequestIds[id]
-		if ok == false {
+		if !ok {
 			return nil, fmt.Errorf("failed to read request vout from batch")
 		}
 		indices = append(indices, vout)
@@ -233,7 +233,8 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to adjust fee: %w", err)
 	}
-	tx, _, err = w.includeMergeTxFee(ctx, tx, mergeTxHexes, onGoingBatch.MergeTxFee)
+
+	tx, onGoingBatch.MergeTxFee, err = w.includeMergeTxFee(ctx, tx, mergeTxHexes, onGoingBatch.MergeTxFee)
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to include merge tx fee: %w", err)
 	}
@@ -269,8 +270,8 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
-	txHash, err := w.handlePostSubmission(ctx, req, tx, onGoingBatch, "")
-	return txHash, err
+	err = w.saveLatestBatch(ctx, req, tx, onGoingBatch, "")
+	return tx.TxHash(), err
 
 }
 
@@ -550,11 +551,11 @@ func (w *Wallet) batchAndBroadcast(ctx context.Context, req []btc.SendRequest, p
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
-	txHash, err := w.handlePostSubmission(ctx, req, tx, previousBatch, CoinbaseBatchID)
-	return txHash, err
+	err = w.saveLatestBatch(ctx, req, tx, previousBatch, CoinbaseBatchID)
+	return tx.TxHash(), err
 }
 
-func (w *Wallet) saveVouts(tx *wire.MsgTx, req []btc.SendRequest) (map[string]int, error) {
+func (w *Wallet) getVoutsFromTx(tx *wire.MsgTx, req []btc.SendRequest) (map[string]int, error) {
 	reqToVout := make(map[string]int)
 	for _, r := range req {
 		ok, id := r.ID()
@@ -999,52 +1000,48 @@ func (w *Wallet) selectAndAddUTXOsForNewOuts(ctx context.Context, tx *wire.MsgTx
 	return tx, nil
 }
 
-func (w *Wallet) handlePostSubmission(ctx context.Context, req []btc.SendRequest, tx *wire.MsgTx, workingBatch *Batch, previousID string) (chainhash.Hash, error) {
+func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx *wire.MsgTx, workingBatch *Batch, previousID string) error {
 
-	batchTx, err := w.indexer.GetTx(ctx, tx.TxHash().String())
+	childCtx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+	defer cancel()
+
+	batchTx, err := w.indexer.GetTx(childCtx, tx.TxHash().String())
 	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to get tx: %w", err)
+		return fmt.Errorf("failed to get tx: %w", err)
 	}
-	reqIDs, err := w.saveVouts(tx, req)
+	reqIDs, err := w.getVoutsFromTx(tx, req)
 	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
+		return fmt.Errorf("failed to save vouts: %w", err)
 	}
 
 	var finalBatch *Batch
 	// Creating A New Batch
-	if len(previousID) > 0 {
+	if previousID == CoinbaseBatchID {
 		if workingBatch != nil {
 			previousID = workingBatch.Tx.TxID
+			for req, vout := range workingBatch.RequestIds {
+				reqIDs[req] = vout
+			}
 		}
-		finalBatch = NewBatch(batchTx, reqIDs, previousID, 0)
-	} else {
-		// Updating OngoingBatch
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 5000*time.Millisecond)
-		defer cancel()
 
+		finalBatch = NewBatch(batchTx, reqIDs, previousID, 0)
+
+	} else {
 		workingBatch.Tx = batchTx
 		workingBatch.PreviousBatchID = batchTx.TxID
 
 		// vouts are necessary for merge requests
-		reqIDs, err := w.saveVouts(tx, req)
-
 		for reqID, vout := range reqIDs {
 			workingBatch.RequestIds[reqID] = vout
 		}
 
-		if err != nil {
-			return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
-		}
-
 		finalBatch = workingBatch
-
 	}
 
-	err = w.cache.SaveLatestBatch(ctx, finalBatch)
+	err = w.cache.SaveLatestBatch(childCtx, finalBatch)
 	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save batch: %w", err)
+		return fmt.Errorf("failed to save batch: %w", err)
 	}
 
-	return tx.TxHash(), nil
+	return nil
 }

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -269,25 +269,6 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
-	reqIDs := []string{}
-	for _, r := range req {
-		pkScript, err := txscript.PayToAddrScript(r.To)
-		if err != nil {
-			return chainhash.Hash{}, fmt.Errorf("failed to get pk script: %w", err)
-		}
-		for _, out := range tx.TxOut {
-			if bytes.Equal(out.PkScript, pkScript) {
-				ok, id := r.ID()
-				if !ok {
-					return chainhash.Hash{}, fmt.Errorf("request id not found")
-				}
-				reqIDs = append(reqIDs, id)
-			}
-		}
-	}
-
-	onGoingBatch.RequestIds = append(onGoingBatch.RequestIds, reqIDs...)
-
 	ctx, cancel := context.WithTimeout(ctx, 5000*time.Millisecond)
 	defer cancel()
 
@@ -297,21 +278,23 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 	}
 	onGoingBatch.Tx = batchTx
 	onGoingBatch.PreviousBatchID = batchTx.TxID
-	err = w.cache.SaveLatestBatch(ctx, onGoingBatch)
-	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save batch: %w", err)
-	}
 
 	// vouts are necessary for merge requests
-	err = w.saveVouts(ctx, tx, req)
+	reqIDs, err := w.saveVouts(tx, req)
+
+	for reqID, vout := range reqIDs {
+		onGoingBatch.RequestIds[reqID] = vout
+	}
+	
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
 	}
 
 	// save the merge tx fee
-	err = w.cache.SaveMergeTxFee(ctx, mergeTxFee)
+	onGoingBatch.MergeTxFee = mergeTxFee
+	err = w.cache.SaveLatestBatch(ctx, onGoingBatch)
 	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save merge tx fee: %w", err)
+		return chainhash.Hash{}, fmt.Errorf("failed to save batch: %w", err)
 	}
 
 	return tx.TxHash(), nil
@@ -362,7 +345,7 @@ func extractMergeIDs(req []btc.SendRequest, batch *Batch) ([]btc.SendRequest, []
 
 		fmt.Println("id to merge", id)
 
-		for _, rID := range batch.RequestIds {
+		for rID := range batch.RequestIds {
 			if rID == id {
 				mergeIDs = append(mergeIDs, id)
 				ok, mergeTxHex := r.MergeTxHex()
@@ -593,53 +576,40 @@ func (w *Wallet) batchAndBroadcast(ctx context.Context, req []btc.SendRequest, p
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
-	reqIDs := []string{}
-	for _, r := range remainingRequests {
-		ok, id := r.ID()
-		if !ok {
-			return chainhash.Hash{}, fmt.Errorf("request id not found")
-		}
-		reqIDs = append(reqIDs, id)
-	}
-
 	batchTx, err := w.indexer.GetTx(ctx, tx.TxHash().String())
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to get tx: %w", err)
 	}
 
-	previousID := "coinbase"
+	previousID := CoinbaseBatchID
 	if previousBatch != nil {
 		previousID = previousBatch.Tx.TxID
 	}
 
-	err = w.cache.SaveLatestBatch(ctx, NewBatch(batchTx, reqIDs, previousID))
-	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save batch: %w", err)
-	}
-
-	err = w.saveVouts(ctx, tx, req)
+	reqIDs, err := w.saveVouts(tx, req)
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
 	}
 
-	err = w.cache.SaveMergeTxFee(ctx, 0)
+	err = w.cache.SaveLatestBatch(ctx, NewBatch(batchTx, reqIDs, previousID, 0))
+
 	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save merge tx fee: %w", err)
+		return chainhash.Hash{}, fmt.Errorf("failed to save batch: %w", err)
 	}
 
 	return tx.TxHash(), nil
 }
 
-func (w *Wallet) saveVouts(ctx context.Context, tx *wire.MsgTx, req []btc.SendRequest) error {
-
+func (w *Wallet) saveVouts(tx *wire.MsgTx, req []btc.SendRequest) (map[string]int, error) {
+	reqToVout := make(map[string]int)
 	for _, r := range req {
 		ok, id := r.ID()
 		if !ok {
-			return fmt.Errorf("request id not found")
+			return reqToVout, fmt.Errorf("request id not found")
 		}
 		toPkScript, err := txscript.PayToAddrScript(r.To)
 		if err != nil {
-			return fmt.Errorf("failed to get to pkscript: %w", err)
+			return reqToVout, fmt.Errorf("failed to get to pkscript: %w", err)
 		}
 		idx := 0
 		for i, out := range tx.TxOut {
@@ -648,13 +618,9 @@ func (w *Wallet) saveVouts(ctx context.Context, tx *wire.MsgTx, req []btc.SendRe
 				break
 			}
 		}
-		err = w.cache.SaveRequestVOUT(ctx, id, idx)
-		if err != nil {
-			return fmt.Errorf("failed to save request vout: %w", err)
-		}
+		reqToVout[id] = idx
 	}
-
-	return nil
+	return reqToVout, nil
 }
 
 func calculateFeeRate(weight, feePaid int64) int64 {

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -970,7 +970,7 @@ func parseIntoTxOutputs(req []btc.SendRequest) ([]*TxOutput, error) {
 
 func (w *Wallet) selectUTXOsForAmount(ctx context.Context, tx *wire.MsgTx, amount int64) ([]*wire.TxIn, int64, error) {
 
-	utxos, err := w.indexer.GetUTXOs(ctx, w.addr)
+	utxos, _, err := w.indexer.GetUTXOsForAmount(ctx, w.addr, amount)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get utxos: %w", err)
 	}
@@ -992,6 +992,10 @@ func (w *Wallet) selectUTXOsForAmount(ctx context.Context, tx *wire.MsgTx, amoun
 			utxosToBeSelected = append(utxosToBeSelected, utxo)
 			amountToBeAdded += utxo.Amount
 		}
+	}
+
+	if amountToBeAdded < amount {
+		return nil, 0, fmt.Errorf("insufficient balance : has %d and need %d", amountToBeAdded, amount)
 	}
 
 	txIns := []*wire.TxIn{}

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -217,6 +217,9 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 
 	tx, err := w.txFromBatch(ctx, onGoingBatch)
 	if err != nil {
+		if strings.Contains(err.Error(), "Transaction not found") {
+			return w.batchAndBroadcast(ctx, req, onGoingBatch)
+		}
 		return chainhash.Hash{}, fmt.Errorf("failed to get raw tx from batch: %w", err)
 	}
 
@@ -568,6 +571,11 @@ func (w *Wallet) batchAndBroadcast(ctx context.Context, req []btc.SendRequest, p
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
+	if previousBatch != nil {
+		fmt.Println(previousBatch.RequestIds)
+		previousBatch.RequestIds = map[string]int{}
+	}
+
 	err = w.saveLatestBatch(ctx, req, tx, previousBatch)
 	return tx.TxHash(), err
 }
@@ -877,7 +885,9 @@ func prettyPrint(anything interface{}) {
 func (w *Wallet) getInAmounts(ctx context.Context, tx *wire.MsgTx) ([]int64, int64, error) {
 	amounts := []int64{}
 	for _, in := range tx.TxIn {
-		prevTx, err := w.indexer.GetTx(ctx, in.PreviousOutPoint.Hash.String())
+		childCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		prevTx, err := w.indexer.GetTx(childCtx, in.PreviousOutPoint.Hash.String())
 		if err != nil {
 			return nil, 0, err
 		}
@@ -899,7 +909,7 @@ func (w *Wallet) getTotalOutAmount(tx *wire.MsgTx) int64 {
 }
 
 func (w *Wallet) batchStatus(ctx context.Context, batch *Batch) (bool, bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	tx, err := w.indexer.GetTx(ctx, batch.Tx.TxID)
 	if err != nil {
@@ -915,6 +925,8 @@ func (w *Wallet) batchStatus(ctx context.Context, batch *Batch) (bool, bool, err
 
 func (w *Wallet) txFromBatch(ctx context.Context, batch *Batch) (*wire.MsgTx, error) {
 	// get the txHex from indexer
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 	txHex, err := w.indexer.GetTxHex(ctx, batch.Tx.TxID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tx hex: %w", err)

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -6,6 +6,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
 	"strings"
 	"time"
 
@@ -195,6 +199,9 @@ func (w *Wallet) handleMergeRequests(tx *wire.MsgTx, req []btc.SendRequest, onGo
 }
 
 func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Hash, error) {
+	if len(req) == 0 {
+		return chainhash.Hash{}, fmt.Errorf("no request found")
+	}
 
 	if err := validateRequests(req, w.addr); err != nil {
 		return chainhash.Hash{}, err
@@ -233,6 +240,10 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 		}
 		return chainhash.Hash{}, fmt.Errorf("failed to get in amounts: %w", err)
 	}
+
+	fee := getDescendantsFee(onGoingBatch.Tx.TxID)
+
+	onGoingBatch.MergeTxFee += fee
 
 	previousFeeRate := calculateFeeRate(int64(onGoingBatch.Tx.Weight), onGoingBatch.Tx.Fee)
 	tx, err = w.adjustFee(ctx, tx, totalInAmount, previousFeeRate)
@@ -405,9 +416,6 @@ func (w *Wallet) mergeTxFee(ctx context.Context, txHex string) (int, error) {
 
 	_, totalInAmount, err := w.getInAmounts(ctx, msgTx)
 	if err != nil {
-		if strings.Contains(err.Error(), "Transaction not found") {
-			return 0, err
-		}
 		return 0, fmt.Errorf("failed to get in amounts: %w", err)
 	}
 
@@ -492,7 +500,6 @@ func (w *Wallet) getReqIDs(req []btc.SendRequest) ([]string, error) {
 
 // TODO: never maintain duplicates
 func (w *Wallet) batchAndBroadcast(ctx context.Context, req []btc.SendRequest, previousBatch *Batch) (chainhash.Hash, error) {
-
 	if previousBatch != nil {
 		requestsToAdd, err := w.getUnconfirmedRequests(ctx, previousBatch)
 		if err != nil {
@@ -532,9 +539,6 @@ func (w *Wallet) batchAndBroadcast(ctx context.Context, req []btc.SendRequest, p
 
 	inValues, totalInAmount, err := w.getInAmounts(ctx, tx)
 	if err != nil {
-		if strings.Contains(err.Error(), "Transaction not found") {
-			return w.batchAndBroadcast(ctx, req, previousBatch)
-		}
 		return chainhash.Hash{}, fmt.Errorf("failed to get in amounts: %w", err)
 	}
 
@@ -670,7 +674,7 @@ func (w *Wallet) includeMergeTxFee(ctx context.Context, tx *wire.MsgTx, mergeTxH
 	var err error
 	if len(mergeTxHexes) > 0 {
 		if mergeTxFee > 0 {
-			tx, err = w.decreaseChangeAmount(tx, mergeTxFee+1)
+			tx, err = w.decreaseChangeAmount(tx, mergeTxFee)
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to decrease change amount: %w", err)
 			}
@@ -679,9 +683,6 @@ func (w *Wallet) includeMergeTxFee(ctx context.Context, tx *wire.MsgTx, mergeTxH
 		for _, mergeTxHex := range mergeTxHexes {
 			fee, err := w.mergeTxFee(ctx, mergeTxHex)
 			if err != nil {
-				if strings.Contains(err.Error(), "Transaction not found") {
-					return nil, 0, nil
-				}
 				return nil, 0, fmt.Errorf("failed to get merge tx fee: %w", err)
 			}
 			tx, err = w.decreaseChangeAmount(tx, int64(fee))
@@ -707,7 +708,7 @@ func (w *Wallet) adjustFee(ctx context.Context, tx *wire.MsgTx, totalInAmount in
 		extraBaseSize = 43
 	}
 
-	feeToBePaid, err := btc.EstimateGuardianFee(tx, w.feeEstimator, w.feeLevel, int(previousFeeRate), 267, extraBaseSize)
+	feeToBePaid, err := btc.EstimateGuardianFee(tx, w.feeEstimator, w.feeLevel, int(previousFeeRate), GuardianChangeSize, extraBaseSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to estimate fee: %w", err)
 	}
@@ -715,7 +716,6 @@ func (w *Wallet) adjustFee(ctx context.Context, tx *wire.MsgTx, totalInAmount in
 	totalOutAmount := w.getTotalOutAmount(tx)
 	previousFee := totalInAmount - totalOutAmount
 	currentFee := feeToBePaid + 1
-
 	if currentFee > int(previousFee) {
 		currentFee -= int(previousFee)
 	} else {
@@ -760,7 +760,7 @@ func (w *Wallet) adjustFee(ctx context.Context, tx *wire.MsgTx, totalInAmount in
 					tx.AddTxIn(txIn)
 				}
 			}
-			newFee, err := btc.EstimateGuardianFee(tx, w.feeEstimator, w.feeLevel, int(previousFeeRate), 265, 43)
+			newFee, err := btc.EstimateGuardianFee(tx, w.feeEstimator, w.feeLevel, int(previousFeeRate), GuardianChangeSize, GuardianWitnessSize)
 			if err != nil {
 				return nil, fmt.Errorf("failed to estimate fee: %w", err)
 			}
@@ -814,9 +814,6 @@ func (w *Wallet) tryAdjustingAmountsForNewOuts(ctx context.Context, tx *wire.Msg
 
 	_, totalInAmount, err := w.getInAmounts(ctx, tx)
 	if err != nil {
-		if strings.Contains(err.Error(), "Transaction not found") {
-			return nil, err
-		}
 		return nil, fmt.Errorf("failed to get in amounts: %w", err)
 	}
 
@@ -1023,7 +1020,6 @@ func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx 
 
 	txCtx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
 	defer cancel()
-
 	batchTx, err := w.indexer.GetTx(txCtx, tx.TxHash().String())
 	if err != nil {
 		if strings.Contains(err.Error(), "Transaction not found") {
@@ -1057,4 +1053,121 @@ func (w *Wallet) saveLatestBatch(ctx context.Context, req []btc.SendRequest, tx 
 	}
 
 	return nil
+}
+
+// func getDescendants (txId string) {
+// 	connCfg := &rpcclient.ConnConfig{
+// 		Host:         "localhost:18443",
+// 		User:         "admin1",
+// 		Pass:         "123",
+// 		HTTPPostMode: true, // Namecoin core only supports HTTP POST mode
+// 		DisableTLS:   true, // Namecoin core does not provide TLS by default
+// 	}
+// 	client, err := rpcclient.New(connCfg, nil)
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// 	defer client.Shutdown()
+// 	result := client.SendCmd("getdescendants")
+// 	fmt.Println(result)
+// }
+
+type RPCRequest struct {
+	Jsonrpc string        `json:"jsonrpc"`
+	ID      string        `json:"id"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+}
+
+type Fees struct {
+	Base       float64 `json:"base"`
+	Modified   float64 `json:"modified"`
+	Ancestor   float64 `json:"ancestor"`
+	Descendant float64 `json:"descendant"`
+}
+
+// Transaction represents a single transaction entry
+type Transaction struct {
+	Vsize             int      `json:"vsize"`
+	Weight            int      `json:"weight"`
+	Time              int64    `json:"time"`
+	Height            int      `json:"height"`
+	DescendantCount   int      `json:"descendantcount"`
+	DescendantSize    int      `json:"descendantsize"`
+	AncestorCount     int      `json:"ancestorcount"`
+	AncestorSize      int      `json:"ancestorsize"`
+	WtxID             string   `json:"wtxid"`
+	Fees              Fees     `json:"fees"`
+	Depends           []string `json:"depends"`
+	SpentBy           []string `json:"spentby"`
+	BIP125Replaceable bool     `json:"bip125-replaceable"`
+	Unbroadcast       bool     `json:"unbroadcast"`
+}
+
+func getDescendantsFee(txId string) int64 {
+	rpcUser := "admin1"
+	rpcPass := "123"
+	rpcURL := "http://0.0.0.0:18443/"
+	verbose := true
+	// Create the JSON-RPC request
+	requestBody := RPCRequest{
+		Jsonrpc: "1.0",
+		ID:      "curltext",
+		Method:  "getmempooldescendants",
+		Params:  []interface{}{txId, verbose}, // Empty params
+	}
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		log.Fatalf("Error marshalling JSON: %v", err)
+	}
+
+	// Create a new HTTP request
+	req, err := http.NewRequest("POST", rpcURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Fatalf("Error creating request: %v", err)
+	}
+
+	// Add headers
+	req.Header.Set("Content-Type", "text/plain")
+	req.SetBasicAuth(rpcUser, rpcPass)
+
+	// Send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Error reading response: %v", err)
+	}
+
+	var apiResponse struct {
+		Result map[string]Transaction `json:"result"`
+		Error  interface{}            `json:"error"`
+		ID     string                 `json:"id"`
+	}
+
+	if err := json.Unmarshal(body, &apiResponse); err != nil {
+		log.Fatalf("Error unmarshalling JSON: %v", err)
+	}
+
+	if len(apiResponse.Result) == 0 {
+		return 0
+	}
+
+	transactions := make([]Transaction, 0, len(apiResponse.Result))
+	for _, tx := range apiResponse.Result {
+		transactions = append(transactions, tx)
+	}
+
+	var sum float64
+	for _, tx := range transactions {
+		sum += tx.Fees.Base
+	}
+
+	return int64(math.Round(sum * 100000000))
 }

--- a/btc/guardian/wallet.go
+++ b/btc/guardian/wallet.go
@@ -233,7 +233,7 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to adjust fee: %w", err)
 	}
-	tx, mergeTxFee, err := w.includeMergeTxFee(ctx, tx, mergeTxHexes, onGoingBatch.MergeTxFee)
+	tx, _, err = w.includeMergeTxFee(ctx, tx, mergeTxHexes, onGoingBatch.MergeTxFee)
 	if err != nil {
 		return chainhash.Hash{}, fmt.Errorf("failed to include merge tx fee: %w", err)
 	}
@@ -269,35 +269,9 @@ func (w *Wallet) Send(ctx context.Context, req []btc.SendRequest) (chainhash.Has
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 5000*time.Millisecond)
-	defer cancel()
+	txHash, err := w.handlePostSubmission(ctx, req, tx, onGoingBatch, "")
+	return txHash, err
 
-	batchTx, err := w.indexer.GetTx(ctx, tx.TxHash().String())
-	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to get tx: %w", err)
-	}
-	onGoingBatch.Tx = batchTx
-	onGoingBatch.PreviousBatchID = batchTx.TxID
-
-	// vouts are necessary for merge requests
-	reqIDs, err := w.saveVouts(tx, req)
-
-	for reqID, vout := range reqIDs {
-		onGoingBatch.RequestIds[reqID] = vout
-	}
-
-	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
-	}
-
-	// save the merge tx fee
-	onGoingBatch.MergeTxFee = mergeTxFee
-	err = w.cache.SaveLatestBatch(ctx, onGoingBatch)
-	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save batch: %w", err)
-	}
-
-	return tx.TxHash(), nil
 }
 
 // removeIndicesFromTx removes the indices from the tx and pushes the remaining txouts to the new tx
@@ -576,28 +550,8 @@ func (w *Wallet) batchAndBroadcast(ctx context.Context, req []btc.SendRequest, p
 		return chainhash.Hash{}, fmt.Errorf("failed to submit tx: %w", err)
 	}
 
-	batchTx, err := w.indexer.GetTx(ctx, tx.TxHash().String())
-	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to get tx: %w", err)
-	}
-
-	previousID := CoinbaseBatchID
-	if previousBatch != nil {
-		previousID = previousBatch.Tx.TxID
-	}
-
-	reqIDs, err := w.saveVouts(tx, req)
-	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
-	}
-
-	err = w.cache.SaveLatestBatch(ctx, NewBatch(batchTx, reqIDs, previousID, 0))
-
-	if err != nil {
-		return chainhash.Hash{}, fmt.Errorf("failed to save batch: %w", err)
-	}
-
-	return tx.TxHash(), nil
+	txHash, err := w.handlePostSubmission(ctx, req, tx, previousBatch, CoinbaseBatchID)
+	return txHash, err
 }
 
 func (w *Wallet) saveVouts(tx *wire.MsgTx, req []btc.SendRequest) (map[string]int, error) {
@@ -1043,4 +997,54 @@ func (w *Wallet) selectAndAddUTXOsForNewOuts(ctx context.Context, tx *wire.MsgTx
 	}
 
 	return tx, nil
+}
+
+func (w *Wallet) handlePostSubmission(ctx context.Context, req []btc.SendRequest, tx *wire.MsgTx, workingBatch *Batch, previousID string) (chainhash.Hash, error) {
+
+	batchTx, err := w.indexer.GetTx(ctx, tx.TxHash().String())
+	if err != nil {
+		return chainhash.Hash{}, fmt.Errorf("failed to get tx: %w", err)
+	}
+	reqIDs, err := w.saveVouts(tx, req)
+	if err != nil {
+		return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
+	}
+
+	var finalBatch *Batch
+	// Creating A New Batch
+	if len(previousID) > 0 {
+		if workingBatch != nil {
+			previousID = workingBatch.Tx.TxID
+		}
+		finalBatch = NewBatch(batchTx, reqIDs, previousID, 0)
+	} else {
+		// Updating OngoingBatch
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 5000*time.Millisecond)
+		defer cancel()
+
+		workingBatch.Tx = batchTx
+		workingBatch.PreviousBatchID = batchTx.TxID
+
+		// vouts are necessary for merge requests
+		reqIDs, err := w.saveVouts(tx, req)
+
+		for reqID, vout := range reqIDs {
+			workingBatch.RequestIds[reqID] = vout
+		}
+
+		if err != nil {
+			return chainhash.Hash{}, fmt.Errorf("failed to save vouts: %w", err)
+		}
+
+		finalBatch = workingBatch
+
+	}
+
+	err = w.cache.SaveLatestBatch(ctx, finalBatch)
+	if err != nil {
+		return chainhash.Hash{}, fmt.Errorf("failed to save batch: %w", err)
+	}
+
+	return tx.TxHash(), nil
 }

--- a/btc/guardian/wallet_test.go
+++ b/btc/guardian/wallet_test.go
@@ -75,8 +75,13 @@ func setupTest(t *testing.T) (*testWallets, context.Context) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 
+	rpcConfig := btc.BitcoinRPCClient{
+		RpcUser: "admin1",
+		RpcPass: "123",
+		RpcURL:  "http://0.0.0.0:18443",
+	}
 	// Create wallets
-	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger)
+	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger, rpcConfig)
 	require.NoError(t, err)
 
 	simpleWallet, err := btc.NewSimpleWallet(privKey, &chainParams, indexer, feeEstimator, btc.MediumFee)
@@ -125,9 +130,13 @@ func setupSimpleFunded(t *testing.T) (*testWallets, context.Context) {
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
-
-	// Create wallets
-	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger)
+	rpcConfig := btc.BitcoinRPCClient{
+		RpcUser: "admin1",
+		RpcPass: "123",
+		RpcURL:  "http://0.0.0.0:18443",
+	}
+	// Create walletstxfrom
+	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger, rpcConfig)
 	require.NoError(t, err)
 
 	simpleWallet, err := btc.NewSimpleWallet(privKey, &chainParams, indexer, feeEstimator, btc.MediumFee)
@@ -157,7 +166,6 @@ func TestGuardianWallet(t *testing.T) {
 
 	setup, ctx := setupTest(t)
 	wallet := setup.guardian
-	// simple := setup.simple
 	amount := int64(100000)
 
 	t.Run("should send funds to a random addresses", func(t *testing.T) {

--- a/btc/guardian/wallet_test.go
+++ b/btc/guardian/wallet_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/catalogfi/blockchain/btc"
 	"github.com/catalogfi/blockchain/btc/guardian"
 	"github.com/catalogfi/blockchain/localnet"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb"
 	"go.uber.org/zap"
@@ -51,7 +52,7 @@ func setupTest(t *testing.T) (*testWallets, context.Context) {
 		for {
 			localnet.MineBTCBlock()
 			rand.NewSource(time.Now().Unix())
-			seconds := time.Duration(rand.Intn(20) + 20)
+			seconds := time.Duration(rand.Intn(20))
 			time.Sleep(seconds * time.Second)
 		}
 	}()
@@ -102,7 +103,7 @@ func setupSimpleFunded(t *testing.T) (*testWallets, context.Context) {
 		for {
 			localnet.MineBTCBlock()
 			rand.NewSource(time.Now().Unix())
-			seconds := time.Duration(rand.Intn(20) + 20)
+			seconds := time.Duration(rand.Intn(5) + 5)
 			time.Sleep(seconds * time.Second)
 		}
 	}()
@@ -191,10 +192,10 @@ func TestGuardianWallet(t *testing.T) {
 	})
 
 	t.Run("should be able to merge merge txs", func(t *testing.T) {
-		for i := 0; i < 1; i++ {
-			inits := rand.Intn(10)
-			redeems := rand.Intn(inits + 1)
-			mergeReqs := rand.Intn(redeems + 1)
+		for i := 0; i < 10; i++ {
+			inits := rand.Intn(25) + 25
+			redeems := (rand.Intn(inits) % 25) + 1
+			mergeReqs := rand.Intn(redeems) + 1
 			normalReqs := rand.Intn(10)
 
 			fmt.Println("inits : ", inits, "\nredeems : ", redeems, "\nmergeReqs : ", mergeReqs, "\nnormalReqs", normalReqs)
@@ -203,16 +204,17 @@ func TestGuardianWallet(t *testing.T) {
 			mergeTxHexes := make(map[string]string)
 			utxos := make(map[string][]btc.Prevout)
 
+			sendReqs := []btc.SendRequest{}
 			for j := 0; j < inits; j++ {
-				tx, err := wallet.Send(ctx, []btc.SendRequest{
-					btc.NewSendRequest(fmt.Sprintf("3_%d", j), amount, simpleWallets[j].Address()),
-				})
-				fmt.Println("after funding simple : ", tx)
-				require.NoError(t, err)
-				require.NotEmpty(t, tx)
-				fmt.Println("after sending to simple the tx is ", tx.String())
-				time.Sleep(5 * time.Second)
+				sendReqs = append(sendReqs, btc.NewSendRequest(fmt.Sprintf("3_%d_%d", i, j), amount, simpleWallets[j].Address()))
 			}
+
+			tx, err := wallet.Send(ctx, sendReqs)
+			require.NoError(t, err)
+			require.NotEmpty(t, tx)
+			fmt.Println("after sending to simple the tx is ", tx.String())
+
+			time.Sleep(time.Duration(5) * time.Second)
 
 			for k := 0; k < redeems; k++ {
 				randomP2PKHAddr2 := randomP2PKHAddr()
@@ -223,8 +225,7 @@ func TestGuardianWallet(t *testing.T) {
 					btc.NewSendRequest(fmt.Sprintf("1_%d", k), amount-fee, randomP2PKHAddr2),
 				}, nil, nil)
 
-				fmt.Println("from ", simpleWallets[k].Address(), " to ==> ", randomP2PKHAddr2.EncodeAddress())
-				fmt.Println("after sending to random Address ", txString)
+				fmt.Println("After sending to random address ", txString)
 
 				require.NoError(t, err)
 				require.NotEmpty(t, txString)
@@ -233,7 +234,6 @@ func TestGuardianWallet(t *testing.T) {
 
 				txx, err := setup.indexer.GetTx(ctx, txString)
 
-				fmt.Println("k ====> ", k)
 				mergeTxHexes[fmt.Sprintf("1_%d", k)] = txHex
 				utxos[fmt.Sprintf("1_%d", k)] = txx.VOUTs
 
@@ -243,37 +243,16 @@ func TestGuardianWallet(t *testing.T) {
 
 			mergeRe := []btc.SendRequest{}
 			for l := 0; l < mergeReqs; l++ {
-
 				fmt.Println("l ==> ", l)
 				for _, out := range utxos[fmt.Sprintf("1_%d", l)] {
 					addr, err := btcutil.DecodeAddress(out.ScriptPubKeyAddress, setup.chainParams)
-					fmt.Println(addr.EncodeAddress(), "  ", out.ScriptPubKeyAddress)
 					require.NoError(t, err)
-					mergeRe = append(mergeRe, btc.NewSendRequestWithInvalidateID(fmt.Sprintf("4_%d", l), int64(out.Value), addr, fmt.Sprintf("3_%d", l), mergeTxHexes[fmt.Sprintf("1_%d", l)]))
+					mergeRe = append(mergeRe, btc.NewSendRequestWithInvalidateID(fmt.Sprintf("4_%d_%d", i, l), int64(out.Value), addr, fmt.Sprintf("3_%d_%d", i, l), mergeTxHexes[fmt.Sprintf("1_%d", l)]))
 				}
-
 			}
 			if len(mergeRe) > 0 {
 				tx, err := wallet.Send(ctx, mergeRe)
-				if err != nil && err.Error() == "no remaining requests to process" {
-					fmt.Println("no remaining requests to process")
-					continue
-				}
-
 				fmt.Println("after merging : ", tx)
-				require.NoError(t, err)
-				require.NotEmpty(t, tx)
-
-			}
-
-			normalRe := []btc.SendRequest{}
-			for i := 0; i < normalReqs; i++ {
-				randomAddr := randomP2PKHAddr()
-				normalRe = append(normalRe, btc.NewSendRequest(fmt.Sprintf("2_%d", i), amount-1000, randomAddr))
-			}
-
-			if len(normalRe) > 0 {
-				tx, err := wallet.Send(ctx, normalRe)
 				if err != nil && err.Error() == "no remaining requests to process" {
 					fmt.Println("no remaining requests to process")
 					continue
@@ -281,7 +260,29 @@ func TestGuardianWallet(t *testing.T) {
 				if err != nil {
 					fmt.Println(err)
 				}
-				fmt.Println("after merging : ", tx)
+
+				require.NoError(t, err)
+				require.NotEmpty(t, tx)
+
+			}
+
+			normalRe := []btc.SendRequest{}
+			for p := 0; p < normalReqs; p++ {
+				randomAddr := randomP2PKHAddr()
+				normalRe = append(normalRe, btc.NewSendRequest(fmt.Sprintf("2_%d_%d", i, p), amount-1000, randomAddr))
+			}
+
+			if len(normalRe) > 0 {
+				tx, err := wallet.Send(ctx, normalRe)
+				fmt.Println("after normal req : ", tx)
+				if err != nil && err.Error() == "no remaining requests to process" {
+					fmt.Println("no remaining requests to process")
+					continue
+				}
+				if err != nil {
+					fmt.Println(err)
+				}
+
 				require.NoError(t, err)
 				require.NotEmpty(t, tx)
 			}
@@ -336,4 +337,28 @@ func indexerClient() btc.IndexerClient {
 		panic(err)
 	}
 	return btc.NewElectrsIndexerClient(logger, "http://localhost:30000", 2*time.Second)
+}
+
+func TestLess(t *testing.T) {
+	setup, ctx := setupSimpleFunded(t)
+	simple := setup.simple
+	gWallet := setup.guardian
+
+	for i := 0; i < 10; i++ {
+		tx, err := simple.Send(ctx, []btc.SendRequest{
+			btc.NewSendRequest(fmt.Sprintf("1_%d", i), 1000, gWallet.Address()),
+		}, nil, nil)
+		if err != nil {
+
+		}
+		assert.NotEmpty(t, tx)
+	}
+
+	tx, err := gWallet.Send(ctx, []btc.SendRequest{
+		btc.NewSendRequest("5", 10000, randomP2PKHAddr()),
+	})
+	fmt.Println(tx.String())
+	if err != nil {
+		fmt.Println(err)
+	}
 }

--- a/btc/guardian/wallet_test.go
+++ b/btc/guardian/wallet_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/catalogfi/blockchain/btc"
 	"github.com/catalogfi/blockchain/btc/guardian"
 	"github.com/catalogfi/blockchain/localnet"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb"
 	"go.uber.org/zap"
@@ -75,13 +74,13 @@ func setupTest(t *testing.T) (*testWallets, context.Context) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 
-	rpcConfig := btc.BitcoinRPCClient{
+	bitcoinRPC := btc.BitcoinRPCClient{
 		RpcUser: "admin1",
 		RpcPass: "123",
 		RpcURL:  "http://0.0.0.0:18443",
 	}
 	// Create wallets
-	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger, rpcConfig)
+	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger, bitcoinRPC)
 	require.NoError(t, err)
 
 	simpleWallet, err := btc.NewSimpleWallet(privKey, &chainParams, indexer, feeEstimator, btc.MediumFee)
@@ -130,13 +129,13 @@ func setupSimpleFunded(t *testing.T) (*testWallets, context.Context) {
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
-	rpcConfig := btc.BitcoinRPCClient{
+	bitcoinRPC := btc.BitcoinRPCClient{
 		RpcUser: "admin1",
 		RpcPass: "123",
 		RpcURL:  "http://0.0.0.0:18443",
 	}
 	// Create walletstxfrom
-	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger, rpcConfig)
+	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger, bitcoinRPC)
 	require.NoError(t, err)
 
 	simpleWallet, err := btc.NewSimpleWallet(privKey, &chainParams, indexer, feeEstimator, btc.MediumFee)
@@ -206,8 +205,6 @@ func TestGuardianWallet(t *testing.T) {
 			mergeReqs := rand.Intn(redeems) + 1
 			normalReqs := rand.Intn(10)
 
-			fmt.Println("inits : ", inits, "\nredeems : ", redeems, "\nmergeReqs : ", mergeReqs, "\nnormalReqs", normalReqs)
-
 			simpleWallets, _ := setupSimpleWallets(t, inits)
 			mergeTxHexes := make(map[string]string)
 			utxos := make(map[string][]btc.Prevout)
@@ -220,7 +217,6 @@ func TestGuardianWallet(t *testing.T) {
 			tx, err := wallet.Send(ctx, sendReqs)
 			require.NoError(t, err)
 			require.NotEmpty(t, tx)
-			fmt.Println("after sending to simple the tx is ", tx.String())
 
 			time.Sleep(time.Duration(5) * time.Second)
 
@@ -233,7 +229,6 @@ func TestGuardianWallet(t *testing.T) {
 					btc.NewSendRequest(fmt.Sprintf("1_%d", k), amount-fee, randomP2PKHAddr2),
 				}, nil, nil)
 
-				fmt.Println("After sending to random address ", txString)
 
 				require.NoError(t, err)
 				require.NotEmpty(t, txString)
@@ -251,7 +246,6 @@ func TestGuardianWallet(t *testing.T) {
 
 			mergeRe := []btc.SendRequest{}
 			for l := 0; l < mergeReqs; l++ {
-				fmt.Println("l ==> ", l)
 				for _, out := range utxos[fmt.Sprintf("1_%d", l)] {
 					addr, err := btcutil.DecodeAddress(out.ScriptPubKeyAddress, setup.chainParams)
 					require.NoError(t, err)
@@ -260,15 +254,11 @@ func TestGuardianWallet(t *testing.T) {
 			}
 			if len(mergeRe) > 0 {
 				tx, err := wallet.Send(ctx, mergeRe)
-				fmt.Println("after merging : ", tx)
 				if err != nil && err.Error() == "no remaining requests to process" {
 					fmt.Println("no remaining requests to process")
 					continue
 				}
-				if err != nil {
-					fmt.Println(err)
-				}
-
+				
 				require.NoError(t, err)
 				require.NotEmpty(t, tx)
 
@@ -345,28 +335,4 @@ func indexerClient() btc.IndexerClient {
 		panic(err)
 	}
 	return btc.NewElectrsIndexerClient(logger, "http://localhost:30000", 2*time.Second)
-}
-
-func TestLess(t *testing.T) {
-	setup, ctx := setupSimpleFunded(t)
-	simple := setup.simple
-	gWallet := setup.guardian
-
-	for i := 0; i < 10; i++ {
-		tx, err := simple.Send(ctx, []btc.SendRequest{
-			btc.NewSendRequest(fmt.Sprintf("1_%d", i), 1000, gWallet.Address()),
-		}, nil, nil)
-		if err != nil {
-
-		}
-		assert.NotEmpty(t, tx)
-	}
-
-	tx, err := gWallet.Send(ctx, []btc.SendRequest{
-		btc.NewSendRequest("5", 10000, randomP2PKHAddr()),
-	})
-	fmt.Println(tx.String())
-	if err != nil {
-		fmt.Println(err)
-	}
 }

--- a/btc/guardian/wallet_test.go
+++ b/btc/guardian/wallet_test.go
@@ -3,6 +3,7 @@ package guardian_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -25,12 +26,33 @@ type testWallets struct {
 	feeRate     int
 }
 
+func setupSimpleWallets(t *testing.T, count int) ([]btc.Wallet, context.Context) {
+	var wallets []btc.Wallet
+	for i := 0; i < count; i++ {
+		privKey, _ := randomPrivKey()
+
+		feeRate := 1
+
+		chainParams := chaincfg.RegressionNetParams
+		feeEstimator := btc.NewFixFeeEstimator(feeRate)
+		indexer := indexerClient()
+
+		simpleWallet, err := btc.NewSimpleWallet(privKey, &chainParams, indexer, feeEstimator, btc.MediumFee)
+		require.NoError(t, err)
+		wallets = append(wallets, simpleWallet)
+	}
+	ctx := context.Background()
+	return wallets, ctx
+}
+
 func setupTest(t *testing.T) (*testWallets, context.Context) {
 	// Start mining blocks in background
 	go func() {
 		for {
 			localnet.MineBTCBlock()
-			time.Sleep(10 * time.Second)
+			rand.NewSource(time.Now().Unix())
+			seconds := time.Duration(rand.Intn(20) + 20)
+			time.Sleep(seconds * time.Second)
 		}
 	}()
 
@@ -74,6 +96,57 @@ func setupTest(t *testing.T) (*testWallets, context.Context) {
 	}, ctx
 }
 
+func setupSimpleFunded(t *testing.T) (*testWallets, context.Context) {
+	// Start mining blocks in background
+	go func() {
+		for {
+			localnet.MineBTCBlock()
+			rand.NewSource(time.Now().Unix())
+			seconds := time.Duration(rand.Intn(20) + 20)
+			time.Sleep(seconds * time.Second)
+		}
+	}()
+
+	ctx := context.Background()
+	privKey, pubKey := randomPrivKey()
+
+	// Setup dependencies
+	guardianClient := guardian.NewGuardianClient(ctx, "http://0.0.0.0:11818", pubKey)
+	levelDB, err := leveldb.OpenFile(t.TempDir(), nil)
+	require.NoError(t, err)
+
+	feeRate := 1
+
+	chainParams := chaincfg.RegressionNetParams
+	feeEstimator := btc.NewFixFeeEstimator(feeRate)
+	cache := guardian.NewCache(levelDB)
+	indexer := indexerClient()
+
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	// Create wallets
+	guardianWallet, err := guardian.NewWallet(guardianClient, privKey, cache, indexer, &chainParams, feeEstimator, logger)
+	require.NoError(t, err)
+
+	simpleWallet, err := btc.NewSimpleWallet(privKey, &chainParams, indexer, feeEstimator, btc.MediumFee)
+	require.NoError(t, err)
+
+	// Fund the guardian wallet
+	addr := simpleWallet.Address()
+	require.NoError(t, err)
+	_, err = localnet.FundBitcoin(addr.String(), indexer)
+	require.NoError(t, err)
+
+	return &testWallets{
+		guardian:    guardianWallet,
+		simple:      simpleWallet,
+		indexer:     indexer,
+		chainParams: &chainParams,
+		feeRate:     feeRate,
+	}, ctx
+}
+
 type AddressesToCheckFundsFor struct {
 	address btcutil.Address
 	amount  int64
@@ -83,7 +156,7 @@ func TestGuardianWallet(t *testing.T) {
 
 	setup, ctx := setupTest(t)
 	wallet := setup.guardian
-	simple := setup.simple
+	// simple := setup.simple
 	amount := int64(100000)
 
 	t.Run("should send funds to a random addresses", func(t *testing.T) {
@@ -118,51 +191,106 @@ func TestGuardianWallet(t *testing.T) {
 	})
 
 	t.Run("should be able to merge merge txs", func(t *testing.T) {
-		for i := 0; i < 10; i++ {
-			tx, err := wallet.Send(ctx, []btc.SendRequest{
-				btc.NewSendRequest(fmt.Sprintf("3_%d", i), amount, simple.Address()),
-			})
-			require.NoError(t, err)
-			require.NotEmpty(t, tx)
-			time.Sleep(5 * time.Second)
+		for i := 0; i < 1; i++ {
+			inits := rand.Intn(10)
+			redeems := rand.Intn(inits + 1)
+			mergeReqs := rand.Intn(redeems + 1)
+			normalReqs := rand.Intn(10)
 
-			randomP2PKHAddr2 := randomP2PKHAddr()
-			fee := int64(1000)
-			txString, err := simple.Send(ctx, []btc.SendRequest{
-				// this amount is after minus fee
-				btc.NewSendRequest(fmt.Sprintf("1_%d", i), amount-fee, randomP2PKHAddr2),
-			}, nil, nil)
-			require.NoError(t, err)
-			require.NotEmpty(t, txString)
+			fmt.Println("inits : ", inits, "\nredeems : ", redeems, "\nmergeReqs : ", mergeReqs, "\nnormalReqs", normalReqs)
 
-			txHex, err := setup.indexer.GetTxHex(ctx, txString)
-			require.NoError(t, err)
+			simpleWallets, _ := setupSimpleWallets(t, inits)
+			mergeTxHexes := make(map[string]string)
+			utxos := make(map[string][]btc.Prevout)
 
-			txx, err := setup.indexer.GetTx(ctx, txString)
-			require.NoError(t, err)
-			require.Equal(t, txx.Fee, fee)
-
-			newReqs := []btc.SendRequest{}
-
-			for _, out := range txx.VOUTs {
-				addr, err := btcutil.DecodeAddress(out.ScriptPubKeyAddress, setup.chainParams)
+			for j := 0; j < inits; j++ {
+				tx, err := wallet.Send(ctx, []btc.SendRequest{
+					btc.NewSendRequest(fmt.Sprintf("3_%d", j), amount, simpleWallets[j].Address()),
+				})
+				fmt.Println("after funding simple : ", tx)
 				require.NoError(t, err)
-				newReqs = append(newReqs, btc.NewSendRequestWithInvalidateID(fmt.Sprintf("4_%d", i), int64(out.Value), addr, fmt.Sprintf("3_%d", i), txHex))
+				require.NotEmpty(t, tx)
+				fmt.Println("after sending to simple the tx is ", tx.String())
+				time.Sleep(5 * time.Second)
 			}
 
-			tx, err = wallet.Send(ctx, newReqs)
-			if err != nil && err.Error() == "no remaining requests to process" {
-				fmt.Println("no remaining requests to process")
-				continue
+			for k := 0; k < redeems; k++ {
+				randomP2PKHAddr2 := randomP2PKHAddr()
+				fee := int64(1000)
+
+				txString, err := simpleWallets[k].Send(ctx, []btc.SendRequest{
+					// this amount is after minus fee
+					btc.NewSendRequest(fmt.Sprintf("1_%d", k), amount-fee, randomP2PKHAddr2),
+				}, nil, nil)
+
+				fmt.Println("from ", simpleWallets[k].Address(), " to ==> ", randomP2PKHAddr2.EncodeAddress())
+				fmt.Println("after sending to random Address ", txString)
+
+				require.NoError(t, err)
+				require.NotEmpty(t, txString)
+				txHex, err := setup.indexer.GetTxHex(ctx, txString)
+				require.NoError(t, err)
+
+				txx, err := setup.indexer.GetTx(ctx, txString)
+
+				fmt.Println("k ====> ", k)
+				mergeTxHexes[fmt.Sprintf("1_%d", k)] = txHex
+				utxos[fmt.Sprintf("1_%d", k)] = txx.VOUTs
+
+				require.NoError(t, err)
+				require.Equal(t, txx.Fee, fee)
 			}
-			require.NoError(t, err)
-			require.NotEmpty(t, tx)
+
+			mergeRe := []btc.SendRequest{}
+			for l := 0; l < mergeReqs; l++ {
+
+				fmt.Println("l ==> ", l)
+				for _, out := range utxos[fmt.Sprintf("1_%d", l)] {
+					addr, err := btcutil.DecodeAddress(out.ScriptPubKeyAddress, setup.chainParams)
+					fmt.Println(addr.EncodeAddress(), "  ", out.ScriptPubKeyAddress)
+					require.NoError(t, err)
+					mergeRe = append(mergeRe, btc.NewSendRequestWithInvalidateID(fmt.Sprintf("4_%d", l), int64(out.Value), addr, fmt.Sprintf("3_%d", l), mergeTxHexes[fmt.Sprintf("1_%d", l)]))
+				}
+
+			}
+			if len(mergeRe) > 0 {
+				tx, err := wallet.Send(ctx, mergeRe)
+				if err != nil && err.Error() == "no remaining requests to process" {
+					fmt.Println("no remaining requests to process")
+					continue
+				}
+
+				fmt.Println("after merging : ", tx)
+				require.NoError(t, err)
+				require.NotEmpty(t, tx)
+
+			}
+
+			normalRe := []btc.SendRequest{}
+			for i := 0; i < normalReqs; i++ {
+				randomAddr := randomP2PKHAddr()
+				normalRe = append(normalRe, btc.NewSendRequest(fmt.Sprintf("2_%d", i), amount-1000, randomAddr))
+			}
+
+			if len(normalRe) > 0 {
+				tx, err := wallet.Send(ctx, normalRe)
+				if err != nil && err.Error() == "no remaining requests to process" {
+					fmt.Println("no remaining requests to process")
+					continue
+				}
+				if err != nil {
+					fmt.Println(err)
+				}
+				fmt.Println("after merging : ", tx)
+				require.NoError(t, err)
+				require.NotEmpty(t, tx)
+			}
 
 		}
 	})
 
 	t.Run("randomly generate addresses and send funds to them", func(t *testing.T) {
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 15; i++ {
 			addr := randomP2PKHAddr()
 			tx, err := wallet.Send(ctx, []btc.SendRequest{
 				btc.NewSendRequest(fmt.Sprintf("5_%d", i), amount, addr),
@@ -170,6 +298,16 @@ func TestGuardianWallet(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, tx)
 		}
+	})
+
+	t.Run("sending empty request", func(t *testing.T) {
+		setup, ctx := setupTest(t)
+		gWallet := setup.guardian
+
+		newReqs := []btc.SendRequest{}
+		tx, err := gWallet.Send(ctx, newReqs)
+		require.Empty(t, tx)
+		require.Error(t, fmt.Errorf("no request found"), err)
 	})
 
 }


### PR DESCRIPTION
Modified RequestIDs in batch struct: from []string to map[string]int to save vouts
Added MergeTxFee field and const CoinbaseBatchID
Modified SaveVouts function to take in tx,req and return a map of RequestID -> Vout
Modified getVoutIndicesForMergeRequests to read from Batch.RequestIDs
Removed MergeTxFee read from cache and added Batch.MergeTxFee
Added handlePostSubmission function to handle data after submit
Renamed Funcs and commented struct
Added logic to retain previousbatch requestIds
modifed context with 10 seconds timeout
return BatchAndBroadcast call - added to SaveLatestBatch, GetInAmounts and its caller funcs
modified String.Contains placement at Send() to ensure evaluation